### PR TITLE
Support for webhook admission API v1

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,6 +109,8 @@ func main() {
 		conf := readConfig(c)
 		simpleServer := httpd.NewSimpleServer(conf.httpdConf)
 
+		webhook.Init()
+
 		var (
 			mutator routes.MutatorController
 			err     error

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD";
-docker tag centeredge/shawarma-webhook:${TRAVIS_BUILD_NUMBER} centeredge/shawarma-webhook:${TRAVIS_TAG};
-docker tag centeredge/shawarma-webhook:${TRAVIS_BUILD_NUMBER} centeredge/shawarma-webhook:latest;
-docker push centeredge/shawarma-webhook:${TRAVIS_TAG};
-docker push centeredge/shawarma-webhook:latest;

--- a/tests/common.yaml
+++ b/tests/common.yaml
@@ -104,5 +104,5 @@ webhooks:
       name: shawarma-webhook
       namespace: kube-system
       path: "/mutate"
-  admissionReviewVersions: ["v1beta1"]
+  admissionReviewVersions: ["v1beta1", "v1"]
   sideEffects: None


### PR DESCRIPTION
Motivation
----------
v1beta1 and v1 of the webhook admission API are the same, but we need to
recognize them and return the correct API version on the response.

Modifications
-------------
Coerce incoming requests to v1 of the API. Return the same API version
in the response, unless missing in which case we default to v1.