### PR TITLE
Monitor file system for certificate changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/CenterEdge/shawarma-webhook
 go 1.16
 
 require (
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli v1.22.5
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	k8s.io/api v0.19.12
 	k8s.io/apimachinery v0.19.12
 	k8s.io/client-go v0.19.12

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,7 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -234,8 +235,9 @@ golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/httpd/file_watcher.go
+++ b/httpd/file_watcher.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpd
+
+import (
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// FileWatcher is an interface we use to watch changes in files
+type FileWatcher interface {
+	Close() error
+}
+
+// OSFileWatcher defines a watch over a file
+type OSFileWatcher struct {
+	file    string
+	watcher *fsnotify.Watcher
+	// onEvent callback to be invoked after the file being watched changes
+	onEvent func()
+}
+
+// NewFileWatcher creates a new FileWatcher
+func NewFileWatcher(file string, onEvent func()) (FileWatcher, error) {
+	fw := OSFileWatcher{
+		file:    file,
+		onEvent: onEvent,
+	}
+	err := fw.watch()
+	return fw, err
+}
+
+// Close ends the watch
+func (f OSFileWatcher) Close() error {
+	return f.watcher.Close()
+}
+
+// watch creates a fsnotify watcher for a file and create of write events
+func (f *OSFileWatcher) watch() error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	f.watcher = watcher
+
+	realFile, err := filepath.EvalSymlinks(f.file)
+	if err != nil {
+		return err
+	}
+
+	dir, file := path.Split(f.file)
+	go func(file string) {
+		for {
+			select {
+			case event := <-watcher.Events:
+				if event.Op&fsnotify.Create == fsnotify.Create ||
+					event.Op&fsnotify.Write == fsnotify.Write {
+					if finfo, err := os.Lstat(event.Name); err != nil {
+						log.Printf("can not lstat file: %v\n", err)
+					} else if finfo.Mode()&os.ModeSymlink != 0 {
+						if currentRealFile, err := filepath.EvalSymlinks(f.file); err == nil &&
+							currentRealFile != realFile {
+							f.onEvent()
+							realFile = currentRealFile
+						}
+						continue
+					}
+					if strings.HasSuffix(event.Name, file) {
+						f.onEvent()
+					}
+				}
+			case err := <-watcher.Errors:
+				if err != nil {
+					log.Printf("error watching file: %v\n", err)
+				}
+			}
+		}
+	}(file)
+	return watcher.Add(dir)
+}


### PR DESCRIPTION
Motivation
----------
When using mounted Kubernetes secrets, we'd like to update the cert used
for TLS whenever the secret is changed. This will handle things like
cert-manager autorenewing without needing to restart the webhook pods.

Modifications
-------------
Implement a filesystem watcher (based on the nginx-ingress code) to
monitor for changes and apply them to the HTTP server.

Note: fsnotify can't be used directly without the file_watcher
abstraction because fsnotify doesn't handle symlinks well. Symlinks are
important for ConfigMap and Secret mounts. Without this special logic,
only the first change would be recognized and not the second.