### PR TITLE
Bugfix: right size sidecar requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ The following environment variables may be used to customize behaviors of the we
 
 The following annotations may be applied to alter behaviors on a specific pod.
 
-| Name                                  | Required | Description |
-| ------------------------------------- | -------- | ----------- |
-| `shawarma.centeredge.io/service-name` | Y        | Name of the K8S service to be monitored, the sidecar is not injected if this annotation is not present |
-| `shawarma.centeredge.io/image`        | N        | Override the image used for Shawarma |
-| `shawarma.centeredge.io/log-level`    | N        | Override the log level used by Shawarma |
-| `shawarma.centeredge.io/state-url`    | N        | Override the URL which receives Shawarma application state (default `http://localhost/applicationstate`) |
+| Name                                   | Required | Description |
+| -------------------------------------- | -------- | ----------- |
+| `shawarma.centeredge.io/service-label` | Y        | Label of the K8S service to be monitored, the sidecar is not injected if this annotation is not present |
+| `shawarma.centeredge.io/image`         | N        | Override the image used for Shawarma |
+| `shawarma.centeredge.io/log-level`     | N        | Override the log level used by Shawarma |
+| `shawarma.centeredge.io/state-url`     | N        | Override the URL which receives Shawarma application state (default `http://localhost/applicationstate`) |

--- a/sidecar.yaml
+++ b/sidecar.yaml
@@ -39,9 +39,9 @@ sidecars:
               fieldPath: metadata.namespace
       resources:
         requests:
-          cpu: "0.1"
-          memory: 128Mi
+          cpu: 10m
+          memory: 75Mi
         limits:
-          cpu: "0.2"
-          memory: 128Mi
+          cpu: 10m
+          memory: 75Mi
 

--- a/sidecar.yaml
+++ b/sidecar.yaml
@@ -19,21 +19,21 @@ sidecars:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['shawarma.centeredge.io/log-level']
-        - name: SHAWARMA_SERVICE
+        - name: ENDPOINT_LABEL
           # References service to monitor
           valueFrom:
             fieldRef:
-              fieldPath: metadata.annotations['shawarma.centeredge.io/service-name']
+              fieldPath: metadata.annotations['shawarma.centeredge.io/service-label']
         - name: SHAWARMA_URL
           # Will POST state to this URL as pod is attached/detached from the service
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['shawarma.centeredge.io/state-url']
-        - name: MY_POD_NAME
+        - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: MY_POD_NAMESPACE
+        - name: NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace

--- a/tests/test-service.yaml
+++ b/tests/test-service.yaml
@@ -37,7 +37,7 @@ spec:
       labels:
         app: shawarma-test
       annotations:
-        shawarma.centeredge.io/service-name: shawarma-test
+        shawarma.centeredge.io/service-label: shawarma-test
         shawarma.centeredge.io/log-level: debug
     spec:
       containers:

--- a/webhook/mutator.go
+++ b/webhook/mutator.go
@@ -251,7 +251,8 @@ func createPatch(pod *corev1.Pod, namespace string, sideCarNames []string, mutat
 			// Apply the configured image
 			for i := range sideCar.Containers {
 				containerCopy := sideCar.Containers[i]
-				containerCopy.Image = strings.Replace(containerCopy.Image, "|SHAWARMA_IMAGE|", shawarmaImage, -1)
+				log.Debugf("Using image %v for container %v", shawarmaImage, containerCopy.Name)
+				containerCopy.Image = shawarmaImage
 
 				sideCarCopy.Containers[i] = containerCopy
 			}
@@ -261,7 +262,8 @@ func createPatch(pod *corev1.Pod, namespace string, sideCarNames []string, mutat
 				volumeCopy := sideCar.Volumes[i]
 
 				if volumeCopy.Secret != nil {
-					volumeCopy.Secret.SecretName = strings.Replace(volumeCopy.Secret.SecretName, "|SHAWARMA_TOKEN_NAME|", secretName, -1)
+					log.Debugf("Updating non-nil volume secret name %v to new secret name %v", volumeCopy.Secret.SecretName, secretName)
+					volumeCopy.Secret.SecretName = secretName
 				}
 
 				sideCarCopy.Volumes[i] = volumeCopy

--- a/webhook/mutator.go
+++ b/webhook/mutator.go
@@ -30,7 +30,7 @@ var (
 
 const (
 	sideCarNameSpace                 = "shawarma.centeredge.io/"
-	injectAnnotation                 = "service-name"
+	injectAnnotation                 = "service-label"
 	imageAnnotation                  = "image"
 	statusAnnotation                 = "status"
 	sideCarInjectionAnnotation       = sideCarNameSpace + injectAnnotation
@@ -195,9 +195,9 @@ func shouldMutate(ignoredList []string, metadata *metav1.ObjectMeta, namespace s
 		return nil, false
 	}
 
-	if serviceName, ok := annotations[sideCarInjectionAnnotation]; ok {
-		if len(serviceName) > 0 {
-			log.Infof("shawarma injection for %v/%v: service-name: %v", namespace, podName, serviceName)
+	if serviceLabel, ok := annotations[sideCarInjectionAnnotation]; ok {
+		if len(serviceLabel) > 0 {
+			log.Infof("shawarma injection for %v/%v: service-label: %v", namespace, podName, serviceLabel)
 			return []string{sideCarName}, true
 		}
 	}


### PR DESCRIPTION
The container requests in the `sidecar.yaml` are way too high. Using Kubecost we noticed the below:

![image](https://user-images.githubusercontent.com/27896502/169895978-2c743686-54ca-44bc-9124-91d974d5fc0d.png)
 This PR reduces the size of the sidecar request to the recommended value for a prod deployment (65% usage target).