### PR TITLE
Allow use of labels to identify services to monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ The following environment variables may be used to customize behaviors of the we
 
 The following annotations may be applied to alter behaviors on a specific pod.
 
-| Name                                  | Required | Description |
-| ------------------------------------- | -------- | ----------- |
-| `shawarma.centeredge.io/service-name` | Y        | Name of the K8S service to be monitored, the sidecar is not injected if this annotation is not present |
-| `shawarma.centeredge.io/image`        | N        | Override the image used for Shawarma |
-| `shawarma.centeredge.io/log-level`    | N        | Override the log level used by Shawarma |
-| `shawarma.centeredge.io/state-url`    | N        | Override the URL which receives Shawarma application state (default `http://localhost/applicationstate`) |
+| Name                                    | Required         | Description |
+| --------------------------------------- | ---------------- | ----------- |
+| `shawarma.centeredge.io/service-name`   | Y (if no labels) | Name of the K8S service to be monitored, the sidecar is not injected if this annotation is not present |
+| `shawarma.centeredge.io/service-labels` | Y (if no name)   | K8S service labels to monitor, comma-delimited ex. `label1=value1,label2=value2` |
+| `shawarma.centeredge.io/image`          | N                | Override the image used for Shawarma |
+| `shawarma.centeredge.io/log-level`      | N                | Override the log level used by Shawarma |
+| `shawarma.centeredge.io/state-url`      | N                | Override the URL which receives Shawarma application state (default `http://localhost/applicationstate`) |

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "Shawarma Webhook"
 	app.Usage = "Kubernetes Mutating Admission Webhook to add the Shawarma sidecar when requested by annotations"
-	app.Copyright = "(c) 2019-2021 CenterEdge Software"
+	app.Copyright = "(c) 2019-2022 CenterEdge Software"
 	app.Version = version
 	app.HideHelpCommand = true
 
@@ -70,7 +70,7 @@ func main() {
 		&cli.StringFlag{
 			Name:    "shawarma-image",
 			Usage:   "Default Docker image",
-			Value:   "centeredge/shawarma:1.0.0",
+			Value:   "centeredge/shawarma:1.1.0-beta003",
 			EnvVars: []string{"SHAWARMA_IMAGE"},
 		},
 		&cli.StringFlag{

--- a/sidecar.yaml
+++ b/sidecar.yaml
@@ -24,6 +24,11 @@ sidecars:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['shawarma.centeredge.io/service-name']
+        - name: SHAWARMA_SERVICE_LABELS
+          # References service to monitor
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['shawarma.centeredge.io/service-labels']
         - name: SHAWARMA_URL
           # Will POST state to this URL as pod is attached/detached from the service
           valueFrom:
@@ -40,8 +45,8 @@ sidecars:
       resources:
         requests:
           cpu: 10m
-          memory: 75Mi
+          memory: 64Mi
         limits:
           cpu: 10m
-          memory: 75Mi
+          memory: 64Mi
 

--- a/tests/test-service.yaml
+++ b/tests/test-service.yaml
@@ -37,7 +37,7 @@ spec:
       labels:
         app: shawarma-test
       annotations:
-        shawarma.centeredge.io/service-name: shawarma-test
+        shawarma.centeredge.io/service-labels: app=shawarma-test
         shawarma.centeredge.io/log-level: debug
     spec:
       containers:

--- a/tests/webhook-deployment.yaml
+++ b/tests/webhook-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: LOG_LEVEL
           value: debug
         - name: SHAWARMA_IMAGE
-          value: centeredge/shawarma:1.0.0
+          value: centeredge/shawarma:1.1.0-beta003
         ports:
         - name: https
           containerPort: 443

--- a/webhook/mutator.go
+++ b/webhook/mutator.go
@@ -31,9 +31,11 @@ var (
 const (
 	sideCarNameSpace                 = "shawarma.centeredge.io/"
 	injectAnnotation                 = "service-name"
+	labelInjectAnnotation            = "service-labels"
 	imageAnnotation                  = "image"
 	statusAnnotation                 = "status"
 	sideCarInjectionAnnotation       = sideCarNameSpace + injectAnnotation
+	sideCarLabelInjectionAnnotation  = sideCarNameSpace + labelInjectAnnotation
 	sideCarInjectionStatusAnnotation = sideCarNameSpace + statusAnnotation
 	sideCarInjectionImageAnnotation  = sideCarNameSpace + imageAnnotation
 	injectedValue                    = "injected"
@@ -198,6 +200,13 @@ func shouldMutate(ignoredList []string, metadata *metav1.ObjectMeta, namespace s
 	if serviceName, ok := annotations[sideCarInjectionAnnotation]; ok {
 		if len(serviceName) > 0 {
 			log.Infof("shawarma injection for %v/%v: service-name: %v", namespace, podName, serviceName)
+			return []string{sideCarName}, true
+		}
+	}
+
+	if serviceLabels, ok := annotations[sideCarLabelInjectionAnnotation]; ok {
+		if len(serviceLabels) > 0 {
+			log.Infof("shawarma injection for %v/%v: service-labels: %v", namespace, podName, serviceLabels)
 			return []string{sideCarName}, true
 		}
 	}


### PR DESCRIPTION
Motivation
------------
Shawarma 1.1.0 adds a feature to select services to monitor by label
instead of service name.

Modifications
---------------
Update the default version to 1.1.0-beta003. We'll bump this again
before final release.

Map a new annotation to the env var in sidecar.yaml.

Update mutator.go to perform injection if only the new label is present.

Update the test examples.