### PR TITLE
Add annotation to customize the listen port

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,4 @@ The following annotations may be applied to alter behaviors on a specific pod.
 | `shawarma.centeredge.io/image`          | N                | Override the image used for Shawarma |
 | `shawarma.centeredge.io/log-level`      | N                | Override the log level used by Shawarma |
 | `shawarma.centeredge.io/state-url`      | N                | Override the URL which receives Shawarma application state (default `http://localhost/applicationstate`) |
+| `shawarma.centeredge.io/listen-port`    | N                | Override the port on which the Shawarma sidecar listens for state requests, (default `8099`) |

--- a/sidecar.yaml
+++ b/sidecar.yaml
@@ -34,6 +34,11 @@ sidecars:
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['shawarma.centeredge.io/state-url']
+        - name: SHAWARMA_LISTEN_PORT
+          # Will listen for HTTP GET of state on this port, localhost traffic only
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['shawarma.centeredge.io/listen-port']
         - name: MY_POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Motivation
------------
Shawarma now supports an HTTP listener with a configurable
port, we should support this with an annotation.

Modifications
---------------
Add the annotation to the sidecar as an environment variable.