### PR TITLE
Support high security K8S clusters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 
 # Copy compiled output to a fresh image
-FROM scratch
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /etc/shawarma-webhook
 
 COPY --from=build ["/app/shawarma-webhook", "/app/sidecar.yaml", "./"]
@@ -33,5 +34,6 @@ ENV CERT_FILE=/etc/shawarma-webhook/certs/tls.crt \
     SHAWARMA_SERVICE_ACCT_NAME=shawarma \
     LOG_LEVEL=warn
 
+USER 65532:65532
 ENTRYPOINT [ "/etc/shawarma-webhook/shawarma-webhook" ]
 CMD []

--- a/main.go
+++ b/main.go
@@ -70,7 +70,7 @@ func main() {
 		&cli.StringFlag{
 			Name:    "shawarma-image",
 			Usage:   "Default Docker image",
-			Value:   "centeredge/shawarma:1.1.0-beta003",
+			Value:   "centeredge/shawarma:1.1.0-beta005",
 			EnvVars: []string{"SHAWARMA_IMAGE"},
 		},
 		&cli.StringFlag{

--- a/sidecar.yaml
+++ b/sidecar.yaml
@@ -10,6 +10,11 @@ sidecars:
     - name: shawarma
       image: "|SHAWARMA_IMAGE|"
       imagePullPolicy: IfNotPresent
+      securityContext:
+        allowPrivilegeEscalation: false
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
       volumeMounts:
       - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
         name: shawarma-token

--- a/tests/webhook-deployment.yaml
+++ b/tests/webhook-deployment.yaml
@@ -21,6 +21,10 @@ spec:
         k8s-app: shawarma-webhook
     spec:
       serviceAccountName: shawarma-webhook
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
       volumes:
       - name: secrets
         secret:
@@ -28,12 +32,14 @@ spec:
       containers:
       - name: shawarma-webhook
         imagePullPolicy: IfNotPresent
-        image: centeredge/shawarma-webhook:test-001
+        image: centeredge/shawarma-webhook:test
+        securityContext:
+          allowPrivilegeEscalation: false
         env:
         - name: LOG_LEVEL
           value: debug
         - name: SHAWARMA_IMAGE
-          value: centeredge/shawarma:1.1.0-beta003
+          value: centeredge/shawarma:1.1.0-beta005
         ports:
         - name: https
           containerPort: 443


### PR DESCRIPTION
Motivation
------------
More secure K8S clusters may require that pods run with
certain security restrictions, such as non-root users.

Modifications
---------------
Change the base image to use a non-root user.

Update the default Shawarma image to one which runs as a
non-root user.

Update the example to apply a securityContext to the webhook
deployment that meets the Restricted policy for K8S.

Update the default sidecar to apply a securityContext to the sidecar
that meets the Restricted policy for K8S.