### PR TITLE
Switch default webhook port to 8443

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ VOLUME [ "/tmp", "/etc/shawarma-webhook/certs" ]
 
 ENV CERT_FILE=/etc/shawarma-webhook/certs/tls.crt \
     KEY_FILE=/etc/shawarma-webhook/certs/tls.key \
-    WEBHOOK_PORT=443 \
+    WEBHOOK_PORT=8443 \
     SHAWARMA_IMAGE=centeredge/shawarma:1.1.0 \
     SHAWARMA_SERVICE_ACCT_NAME=shawarma \
     LOG_LEVEL=warn

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following environment variables may be used to customize behaviors of the we
 | Name                       | Default                              | Description |
 | -------------------------- | ------------------------------------ | ----------- |
 | LOG_LEVEL                  | warn                                 | Log level for the admission webhook |
-| WEBHOOK_PORT               | 443                                  | Port used by the admission webhook |
+| WEBHOOK_PORT               | 8443                                 | Port used by the admission webhook |
 | CERT_FILE                  | /etc/shawarma-webhook/certs/tls.crt  | Certificate file used for TLS by the admission webhook |
 | KEY_FILE                   | /etc/shawarma-webhook/certs/tls.key  | Key file used for TLS by the admission webhook |
 | SWAWARMA_IMAGE             | centeredge/shawarma:1.0.0            | Default Shawarma image |

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 			Name:    "port",
 			Aliases: []string{"p"},
 			Usage:   "Set the listening port number",
-			Value:   443,
+			Value:   8443,
 			EnvVars: []string{"WEBHOOK_PORT"},
 		},
 		&cli.StringFlag{

--- a/tests/test-service.yaml
+++ b/tests/test-service.yaml
@@ -9,7 +9,7 @@ spec:
   type: ClusterIP
   ports:
   - name: http
-    port: 80
+    port: 8080
     targetPort: http
     protocol: TCP
   selector:
@@ -38,15 +38,16 @@ spec:
         app: shawarma-test
       annotations:
         shawarma.centeredge.io/service-labels: app=shawarma-test
+        shawarma.centeredge.io/state-url: http://localhost:8080/applicationstate
         shawarma.centeredge.io/log-level: debug
     spec:
       containers:
       - name: shawarma-test
         imagePullPolicy: IfNotPresent
-        image: httpd
+        image: mendhak/http-https-echo
         ports:
         - name: http
-          containerPort: 80
+          containerPort: 8080
         resources:
           requests:
             cpu: 500m

--- a/tests/webhook-deployment.yaml
+++ b/tests/webhook-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           value: centeredge/shawarma:1.1.0
         ports:
         - name: https
-          containerPort: 443
+          containerPort: 8443
         volumeMounts:
         - name: secrets
           mountPath: /etc/shawarma-webhook/certs


### PR DESCRIPTION
Motivation
------------
Many modern K8S deployments using containerd have difficulty using ports < 1024.