### PR TITLE
Switch to using the pod service account by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ ENV CERT_FILE=/etc/shawarma-webhook/certs/tls.crt \
     KEY_FILE=/etc/shawarma-webhook/certs/tls.key \
     WEBHOOK_PORT=8443 \
     SHAWARMA_IMAGE=centeredge/shawarma:1.1.0 \
-    SHAWARMA_SERVICE_ACCT_NAME=shawarma \
     LOG_LEVEL=warn
 
 USER 65532:65532

--- a/routes/mutator.go
+++ b/routes/mutator.go
@@ -23,7 +23,7 @@ type SideCar struct {
 	Sidecar webhook.SideCar `json:"sidecar"`
 }
 
-func loadConfig(sideCarConfigFile string) (map[string]*webhook.SideCar, error) {
+func loadConfig(sideCarConfigFile string) (map[string]webhook.SideCar, error) {
 	data, err := ioutil.ReadFile(sideCarConfigFile)
 	if err != nil {
 		return nil, err
@@ -35,9 +35,9 @@ func loadConfig(sideCarConfigFile string) (map[string]*webhook.SideCar, error) {
 		return nil, err
 	}
 
-	mapOfSideCar := make(map[string]*webhook.SideCar)
+	mapOfSideCar := make(map[string]webhook.SideCar)
 	for _, configuration := range cfg.Sidecars {
-		mapOfSideCar[configuration.Name] = &configuration.Sidecar
+		mapOfSideCar[configuration.Name] = configuration.Sidecar
 	}
 
 	return mapOfSideCar, nil

--- a/sidecar.yaml
+++ b/sidecar.yaml
@@ -1,6 +1,57 @@
 sidecars:
 - name: shawarma
   sidecar:
+    containers:
+    - name: shawarma
+      image: "|SHAWARMA_IMAGE|"
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        allowPrivilegeEscalation: false
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
+      env:
+        - name: LOG_LEVEL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['shawarma.centeredge.io/log-level']
+        - name: SHAWARMA_SERVICE
+          # References service to monitor
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['shawarma.centeredge.io/service-name']
+        - name: SHAWARMA_SERVICE_LABELS
+          # References service to monitor
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['shawarma.centeredge.io/service-labels']
+        - name: SHAWARMA_URL
+          # Will POST state to this URL as pod is attached/detached from the service
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['shawarma.centeredge.io/state-url']
+        - name: SHAWARMA_LISTEN_PORT
+          # Will listen for HTTP GET of state on this port, localhost traffic only
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['shawarma.centeredge.io/listen-port']
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          cpu: 25m
+          memory: 64Mi
+- name: shawarma-withtoken
+  sidecar:
     volumes:
     - name: shawarma-token
       secret:
@@ -54,9 +105,8 @@ sidecars:
               fieldPath: metadata.namespace
       resources:
         requests:
-          cpu: 10m
+          cpu: 25m
           memory: 64Mi
         limits:
-          cpu: 10m
+          cpu: 25m
           memory: 64Mi
-

--- a/tests/common.yaml
+++ b/tests/common.yaml
@@ -5,23 +5,6 @@ metadata:
   labels:
     shawarma-injection: enabled
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: shawarma
-  namespace: shawarma-test
-secrets:
-  - name: shawarma-token
----
-apiVersion: v1
-kind: Secret
-type: kubernetes.io/service-account-token
-metadata:
- name: shawarma-token
- namespace: shawarma-test
- annotations:
-   kubernetes.io/service-account.name: shawarma
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -35,36 +18,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: shawarma
+  name: shawarma-default
   namespace: shawarma-test
 subjects:
 - kind: ServiceAccount
-  name: shawarma
+  name: default
 roleRef:
   kind: Role
   name: shawarma
-  apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: shawarma-webhook
-rules:
-- apiGroups: [""]
-  resources: ["serviceaccounts"]
-  verbs: ["get", "watch", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: shawarma
-subjects:
-- kind: ServiceAccount
-  name: shawarma-webhook
-  namespace: kube-system
-roleRef:
-  kind: ClusterRole
-  name: shawarma-webhook
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1

--- a/tests/webhook-deployment.yaml
+++ b/tests/webhook-deployment.yaml
@@ -39,7 +39,7 @@ spec:
         - name: LOG_LEVEL
           value: debug
         - name: SHAWARMA_IMAGE
-          value: centeredge/shawarma:1.1.0
+          value: centeredge/shawarma:2.0.0-beta001
         ports:
         - name: https
           containerPort: 8443


### PR DESCRIPTION
Motivation
------------
Since K8S 1.24, service accounts don't automatically generate `Secret` resources that contain a token that never expires. While it is possible to make such a token manually, it is more difficult to find the token because the `ServiceAccount` no longer gets a reference to the `Secret`. Additionally, this approach is less secure because the token doesn't expire and is not rotated.

Modifications
---------------
By default, assume that the service account for the pod has the access rights to `Endpoints` required by Shawarma. This eliminates the need to handle tokens altogether. This also eliminates the need to grant RBAC rights to the webhook as well. The user may still opt-in to the old behavior using the `SHAWARMA_SERVICE_ACCT_NAME` environment variable or `shawarma-service-acct-name` command line switch.