### PR TITLE
Monitor sidecar config for changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,7 @@ allocations or other details of the sidecar.
 The example contains two different sidecar definitions `shawarma` and `shawarma-withtoken`. The default is `shawarma`, but `shawarma-withtoken`
 is used if the `SHAWARMA_SERVICE_ACCT_NAME` OR `SHAWARMA_SECRET_TOKEN_NAME` environment variables (or equivalent command line arguments) are used
 to provide legacy API authentication via a `Secret`.
+
+If the configuration file is mounted from a `ConfigMap` it will be monitored for changes. When changes are detected, the new configuration
+will be used for any newly created pods going forward. This allows the configuration to be changed without the need to restart the webhook deployment.
+An example is available at [webhook-deployment-custom.yaml](./tests/webhook-deployment-custom.yaml).

--- a/filewatcher/file_watcher.go
+++ b/filewatcher/file_watcher.go
@@ -45,11 +45,11 @@ func NewFileWatcher(file string, onEvent func(), logger *zap.Logger) (FileWatche
 		logger:  logger,
 	}
 	err := fw.watch()
-	return &fw, err
+	return fw, err
 }
 
 // Close ends the watch
-func (f *OSFileWatcher) Close() error {
+func (f OSFileWatcher) Close() error {
 	return f.watcher.Close()
 }
 

--- a/filewatcher/file_watcher.go
+++ b/filewatcher/file_watcher.go
@@ -45,11 +45,11 @@ func NewFileWatcher(file string, onEvent func(), logger *zap.Logger) (FileWatche
 		logger:  logger,
 	}
 	err := fw.watch()
-	return fw, err
+	return &fw, err
 }
 
 // Close ends the watch
-func (f OSFileWatcher) Close() error {
+func (f *OSFileWatcher) Close() error {
 	return f.watcher.Close()
 }
 

--- a/go.sum
+++ b/go.sum
@@ -72,7 +72,6 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -113,7 +112,6 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
 golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.35.0 h1:bZBVKBudEyhRcajGcNc3jIfWPqV4y/Kt2XcoigOWtDQ=

--- a/httpd/simpleserver.go
+++ b/httpd/simpleserver.go
@@ -50,8 +50,8 @@ type simpleServerImpl struct {
 	mux    *http.ServeMux
 
 	certMutex sync.RWMutex
-	certWatcher *filewatcher.FileWatcher
-	keyWatcher *filewatcher.FileWatcher
+	certWatcher filewatcher.FileWatcher
+	keyWatcher filewatcher.FileWatcher
 	keyPair *tls.Certificate
 }
 
@@ -71,7 +71,7 @@ func (s *simpleServerImpl) Start(errs chan error) {
 		errs <- err
 		return
 	}
-	s.certWatcher = &certWatcher
+	s.certWatcher = certWatcher
 
 	keyWatcher, err := filewatcher.NewFileWatcher(s.conf.KeyFile, func() {
 		err := s.load()
@@ -84,7 +84,7 @@ func (s *simpleServerImpl) Start(errs chan error) {
 		errs <- err
 		return
 	}
-	s.keyWatcher = &keyWatcher
+	s.keyWatcher = keyWatcher
 
 	// Load initially
 	err = s.load()
@@ -134,12 +134,12 @@ func (s *simpleServerImpl) Shutdown() {
 	s.server.Shutdown(context.Background())
 
 	if s.certWatcher != nil {
-		(*s.certWatcher).Close()
+		s.certWatcher.Close()
 		s.certWatcher = nil
 	}
 
 	if s.keyWatcher != nil {
-		(*s.keyWatcher).Close()
+		s.keyWatcher.Close()
 		s.keyWatcher = nil
 	}
 }

--- a/main.go
+++ b/main.go
@@ -153,13 +153,8 @@ func main() {
 }
 
 func addRoutes(simpleServer httpd.SimpleServer, conf *config) (routes.MutatorController, error) {
-	sideCars, err := webhook.LoadSideCars(conf.sideCarConfigFile, conf.httpdConf.Logger)
-	if err != nil {
-		return nil, err
-	}
-
 	mutator, err := routes.NewMutatorController(&webhook.MutatorConfig{
-		SideCars:                sideCars,
+		SideCarConfigFile:       conf.sideCarConfigFile,
 		ShawarmaImage:           conf.shawarmaImage,
 		NativeSidecars:          conf.nativeSidecars,
 		ShawarmaServiceAcctName: conf.shawarmaServiceAcctName,

--- a/tests/webhook-deployment-custom.yaml
+++ b/tests/webhook-deployment-custom.yaml
@@ -1,0 +1,194 @@
+# This example configuration demonstrates a ConfigMap with a custom sidecar configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shawarma-sidecars
+  namespace: kube-system
+data:
+  sidecars.yaml: |
+    sidecars:
+    - name: shawarma
+      sidecar:
+        containers:
+        - name: shawarma
+          image: "|SHAWARMA_IMAGE|"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+          env:
+            - name: LOG_LEVEL
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['shawarma.centeredge.io/log-level']
+            - name: SHAWARMA_SERVICE
+              # References service to monitor
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['shawarma.centeredge.io/service-name']
+            - name: SHAWARMA_SERVICE_LABELS
+              # References service to monitor
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['shawarma.centeredge.io/service-labels']
+            - name: SHAWARMA_URL
+              # Will POST state to this URL as pod is attached/detached from the service
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['shawarma.centeredge.io/state-url']
+            - name: SHAWARMA_LISTEN_PORT
+              # Will listen for HTTP GET of state on this port, localhost traffic only
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['shawarma.centeredge.io/listen-port']
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 25m
+              memory: 64Mi
+    - name: shawarma-withtoken
+      sidecar:
+        volumes:
+        - name: shawarma-token
+          secret:
+            defaultMode: 420
+            secretName: "|SHAWARMA_TOKEN_NAME|"
+        containers:
+        - name: shawarma
+          image: "|SHAWARMA_IMAGE|"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            name: shawarma-token
+            readOnly: true
+          env:
+            - name: LOG_LEVEL
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['shawarma.centeredge.io/log-level']
+            - name: SHAWARMA_SERVICE
+              # References service to monitor
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['shawarma.centeredge.io/service-name']
+            - name: SHAWARMA_SERVICE_LABELS
+              # References service to monitor
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['shawarma.centeredge.io/service-labels']
+            - name: SHAWARMA_URL
+              # Will POST state to this URL as pod is attached/detached from the service
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['shawarma.centeredge.io/state-url']
+            - name: SHAWARMA_LISTEN_PORT
+              # Will listen for HTTP GET of state on this port, localhost traffic only
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['shawarma.centeredge.io/listen-port']
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 25m
+              memory: 64Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shawarma-webhook
+  namespace: kube-system
+  labels:
+    k8s-app: shawarma-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: shawarma-webhook
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        k8s-app: shawarma-webhook
+    spec:
+      serviceAccountName: shawarma-webhook
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
+      volumes:
+      - name: secrets
+        secret:
+          secretName: shawarma-webhook-certificate
+      - name: sidecars
+        configMap:
+          name: shawarma-sidecars
+      containers:
+      - name: shawarma-webhook
+        imagePullPolicy: IfNotPresent
+        image: centeredge/shawarma-webhook:test
+        securityContext:
+          allowPrivilegeEscalation: false
+        args:
+        - --config
+        - /etc/shawarma-webhook/sidecars/sidecars.yaml
+        env:
+        - name: LOG_LEVEL
+          value: debug
+        - name: SHAWARMA_IMAGE
+          value: centeredge/shawarma:2.0.0-beta001
+        ports:
+        - name: https
+          containerPort: 8443
+        volumeMounts:
+        - name: secrets
+          mountPath: /etc/shawarma-webhook/certs
+          readOnly: true
+        - name: sidecars
+          mountPath: /etc/shawarma-webhook/sidecars
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /health
+            port: https
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+        resources:
+          requests:
+            cpu: 500m
+            memory: 256Mi
+          limits:
+            cpu: 1000m
+            memory: 512Mi

--- a/tests/webhook-deployment.yaml
+++ b/tests/webhook-deployment.yaml
@@ -46,6 +46,7 @@ spec:
         volumeMounts:
         - name: secrets
           mountPath: /etc/shawarma-webhook/certs
+          readOnly: true
         livenessProbe:
           httpGet:
             scheme: HTTPS

--- a/webhook/mutator.go
+++ b/webhook/mutator.go
@@ -52,7 +52,7 @@ type unversionedAdmissionReview struct {
 type patchOperation struct {
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`
-	Value interface{} `json:"value,omitempty"`
+	Value any         `json:"value,omitempty"`
 }
 
 type MutatorConfig struct {

--- a/webhook/mutator.go
+++ b/webhook/mutator.go
@@ -124,6 +124,7 @@ func NewMutator(config *MutatorConfig) (*Mutator, error) {
 		monitor.Shutdown()
 		return nil, fmt.Errorf("failed to start side car monitor: %w", err)
 	}
+
 	return mutator, nil
 }
 

--- a/webhook/mutator.go
+++ b/webhook/mutator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -55,9 +56,9 @@ type patchOperation struct {
 }
 
 type MutatorConfig struct {
-	SideCars                map[string]*SideCar
+	SideCarConfigFile       string
 	ShawarmaImage           string
-	NativeSidecars      bool
+	NativeSidecars      	bool
 	ShawarmaServiceAcctName string
 	ShawarmaSecretTokenName string
 	Logger					*zap.Logger
@@ -65,13 +66,16 @@ type MutatorConfig struct {
 
 /*Mutator is the interface for mutating webhook*/
 type Mutator struct {
-	sideCars                map[string]*SideCar
+	sideCars                atomic.Value
+	sideCarMonitor          *SideCarMonitor
+	sideCarConfigChange     chan map[string]*SideCar
+
 	shawarmaImage           string
-	nativeSidecars    bool
+	nativeSidecars          bool
 	shawarmaServiceAcctName string
 	shawarmaSecretTokenName string
 	serviceAcctMonitors     *ServiceAcctMonitorSet
-	Logger					*zap.Logger
+	Logger                  *zap.Logger
 }
 
 func Init() {
@@ -83,8 +87,8 @@ func NewMutator(config *MutatorConfig) (*Mutator, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config is required")
 	}
-	if config.SideCars == nil {
-		return nil, fmt.Errorf("config.SideCars is required")
+	if config.SideCarConfigFile == "" {
+		return nil, fmt.Errorf("config.SideCarConfigFile is required")
 	}
 	if config.ShawarmaImage == "" {
 		return nil, fmt.Errorf("config.ShawarmaImage is required")
@@ -93,22 +97,48 @@ func NewMutator(config *MutatorConfig) (*Mutator, error) {
 		return nil, fmt.Errorf("config.Logger is required")
 	}
 
-	return &Mutator{
-		sideCars:                config.SideCars,
+	mutator := &Mutator{
+		sideCars:                atomic.Value{},
+		sideCarConfigChange:     make(chan map[string]*SideCar),
 		shawarmaImage:           config.ShawarmaImage,
 		nativeSidecars:          config.NativeSidecars,
 		shawarmaServiceAcctName: config.ShawarmaServiceAcctName,
 		shawarmaSecretTokenName: config.ShawarmaSecretTokenName,
 		serviceAcctMonitors:     NewServiceAcctMonitorSet(config.Logger),
-		Logger:					 config.Logger,
-	}, nil
+		Logger:                  config.Logger,
+	}
+
+	go func() {
+		for sideCarConfig := range mutator.sideCarConfigChange {
+			mutator.sideCars.Store(sideCarConfig)
+		}
+	}()
+
+	monitor, err := NewSideCarMonitor(config.SideCarConfigFile, mutator.sideCarConfigChange, config.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create side car monitor: %w", err)
+	}
+	mutator.sideCarMonitor = monitor
+	
+	return mutator, nil
 }
 
 // Shutdown the mutator
 func (mutator *Mutator) Shutdown() {
 	if mutator.serviceAcctMonitors != nil {
 		mutator.serviceAcctMonitors.StopAll()
+		mutator.serviceAcctMonitors = nil
 	}
+
+	if mutator.sideCarMonitor != nil {
+		mutator.sideCarMonitor.Shutdown()
+		mutator.sideCarMonitor = nil
+		close(mutator.sideCarConfigChange)
+	}
+}
+
+func (mutator *Mutator) GetSideCars() map[string]*SideCar {
+	return mutator.sideCars.Load().(map[string]*SideCar)
 }
 
 /*Mutate function performs the actual mutation of pod spec*/
@@ -310,8 +340,10 @@ func createPatch(pod *corev1.Pod, namespace string, sideCarNames []string, mutat
 		}
 	}
 
+	// Atomic get of the current side cars to prevent errors if they mutate while we're processing
+	sideCars := mutator.GetSideCars()
 	for _, name := range sideCarNames {
-		if sideCarSrc, ok := mutator.sideCars[name]; ok {
+		if sideCarSrc, ok := sideCars[name]; ok {
 			sideCar := sideCarSrc.DeepCopy()
 
 			for i, container := range sideCar.Containers {

--- a/webhook/mutator.go
+++ b/webhook/mutator.go
@@ -138,7 +138,15 @@ func (mutator *Mutator) Shutdown() {
 }
 
 func (mutator *Mutator) GetSideCars() map[string]*SideCar {
-	return mutator.sideCars.Load().(map[string]*SideCar)
+	val := mutator.sideCars.Load()
+	if val == nil {
+		return make(map[string]*SideCar)
+	}
+	sideCars, ok := val.(map[string]*SideCar)
+	if !ok {
+		return make(map[string]*SideCar)
+	}
+	return sideCars
 }
 
 /*Mutate function performs the actual mutation of pod spec*/

--- a/webhook/mutator.go
+++ b/webhook/mutator.go
@@ -120,8 +120,10 @@ func NewMutator(config *MutatorConfig) (*Mutator, error) {
 		}
 	}()
 
-	monitor.Start()
-	
+	if err := monitor.Start(); err != nil {
+		monitor.Shutdown()
+		return nil, fmt.Errorf("failed to start side car monitor: %w", err)
+	}
 	return mutator, nil
 }
 

--- a/webhook/sidecar_monitor.go
+++ b/webhook/sidecar_monitor.go
@@ -10,7 +10,7 @@ import (
 type SideCarMonitor struct {
 	filePath string
 	output chan<- map[string]*SideCar
-	watcher *filewatcher.FileWatcher
+	watcher filewatcher.FileWatcher
 	logger  *zap.Logger
 }
 
@@ -38,7 +38,7 @@ func NewSideCarMonitor(filePath string, output chan<- map[string]*SideCar, logge
 		return nil, err
 	}
 
-	monitor.watcher = &watcher
+	monitor.watcher = watcher
 
 	// Perform initial load
 	monitor.processFile()
@@ -48,7 +48,7 @@ func NewSideCarMonitor(filePath string, output chan<- map[string]*SideCar, logge
 
 func (monitor *SideCarMonitor) Shutdown() {
 	if monitor.watcher != nil {
-		(*monitor.watcher).Close()
+		monitor.watcher.Close()
 		monitor.watcher = nil
 	}
 }

--- a/webhook/sidecar_monitor.go
+++ b/webhook/sidecar_monitor.go
@@ -1,0 +1,66 @@
+package webhook
+
+import (
+	"fmt"
+
+	"github.com/CenterEdge/shawarma-webhook/filewatcher"
+	"go.uber.org/zap"
+)
+
+type SideCarMonitor struct {
+	filePath string
+	output chan<- map[string]*SideCar
+	watcher *filewatcher.FileWatcher
+	logger  *zap.Logger
+}
+
+func NewSideCarMonitor(filePath string, output chan<- map[string]*SideCar, logger *zap.Logger) (*SideCarMonitor, error) {
+	if filePath == "" {
+		return nil, fmt.Errorf("filePath is required")
+	}
+	if logger == nil {
+		return nil, fmt.Errorf("logger is required")
+	}
+
+	monitor := &SideCarMonitor{
+		filePath: filePath,
+		output:  output,
+		logger:  logger,
+	}
+
+	watcher, err := filewatcher.NewFileWatcher(filePath, func() {
+		logger.Debug("File changed",
+			zap.String("file", filePath))
+
+		monitor.processFile()
+	}, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	monitor.watcher = &watcher
+
+	// Perform initial load
+	monitor.processFile()
+
+	return monitor, nil
+}
+
+func (monitor *SideCarMonitor) Shutdown() {
+	if monitor.watcher != nil {
+		(*monitor.watcher).Close()
+		monitor.watcher = nil
+	}
+}
+
+func (monitor *SideCarMonitor) processFile() {
+	data, err := LoadSideCars(monitor.filePath, monitor.logger)
+	if err != nil {
+		monitor.logger.Error("Invalid side car configuration file",
+			zap.Error(err))
+
+		monitor.output <- make(map[string]*SideCar)
+	} else {
+		monitor.output <- data
+	}
+}


### PR DESCRIPTION
Motivation
----------
When mounting custom sidecar configuration via a ConfigMap, it would be valuable if ConfigMap updates could be applied without restarting the webhook deployment.

Modifications
-------------
- Move filewatcher to a common module and switch to zap logging. A primary motivator is to avoid lstat error logs for ConfigMap updates to `data`, `data_tmp`, etc by making them debug level logs.
- Don't fail on startup if there is a bad sidecar configuration, instead simply log the error and treat it as if the file was empty
- Monitor for ongoing changes and swap the configuration atomically